### PR TITLE
[Feature] Empty message view

### DIFF
--- a/DataSourceController.podspec
+++ b/DataSourceController.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = 'DataSourceController'
-  spec.version      = '1.0.0'
+  spec.version      = '1.1.0'
   spec.summary      = 'A controller to handle data sources'
   spec.description  = 'This framework provides a controller to manage table view and collection views datasources'
   spec.license      = { :type => 'MIT', :file => 'LICENSE' }

--- a/DataSourceController/Protocols/DataSourceControllerDelegate.swift
+++ b/DataSourceController/Protocols/DataSourceControllerDelegate.swift
@@ -3,7 +3,9 @@
 import UIKit
 
 public protocol DataSourceControllerDelegate: AnyObject {
+    @available(*, deprecated, message: "Use 'backgroundEmptyView(for:)' instead")
     func backgroundMessageLabel(for view: UIView) -> UILabel?
+    func backgroundEmptyView(for view: UIView) -> UIView?
     func dataSourceWasMutated(_ datasource: DataSourceController)
     func dataSourceWasMutated(_ datasource: DataSourceController, section: Int)
     func dataSourceWasMutated(_ datasource: DataSourceController, rows: [IndexPath])
@@ -11,6 +13,7 @@ public protocol DataSourceControllerDelegate: AnyObject {
 
 public extension DataSourceControllerDelegate {
     func backgroundMessageLabel(for _: UIView) -> UILabel? { return nil }
+    func backgroundEmptyView(for _: UIView) -> UIView? { return nil }
     func dataSourceWasMutated(_: DataSourceController) {}
     func dataSourceWasMutated(_: DataSourceController, section _: Int) {}
     func dataSourceWasMutated(_: DataSourceController, rows _: [IndexPath]) {}

--- a/DataSourceController/UIKit+DataSource/UICollectionViewDataSource.swift
+++ b/DataSourceController/UIKit+DataSource/UICollectionViewDataSource.swift
@@ -5,10 +5,11 @@ import UIKit
 extension DataSourceController: UICollectionViewDataSource {
     public func numberOfSections(in collectionView: UICollectionView) -> Int {
         if totalRowCount == 0 {
-            if collectionView.backgroundView == nil || !(collectionView.backgroundView is UILabel) {
-                collectionView.backgroundView = delegate?.backgroundMessageLabel(for: collectionView)
+            let backgroundView = delegate?.backgroundEmptyView(for: collectionView) ?? delegate?.backgroundMessageLabel(for: collectionView)
+            if backgroundView != nil {
+                collectionView.backgroundView = backgroundView
+	            collectionView.backgroundView?.isHidden = false
             }
-            collectionView.backgroundView?.isHidden = false
         } else {
             collectionView.backgroundView?.isHidden = true
         }

--- a/DataSourceController/UIKit+DataSource/UITableViewDataSource.swift
+++ b/DataSourceController/UIKit+DataSource/UITableViewDataSource.swift
@@ -5,11 +5,12 @@ import UIKit
 extension DataSourceController: UITableViewDataSource {
     public func numberOfSections(in tableView: UITableView) -> Int {
         if totalRowCount == 0 {
-            if tableView.backgroundView == nil || !(tableView.backgroundView is UILabel) {
-                tableView.backgroundView = delegate?.backgroundMessageLabel(for: tableView)
+            let backgroundView = delegate?.backgroundEmptyView(for: tableView) ?? delegate?.backgroundMessageLabel(for: tableView)
+            if backgroundView != nil {
+                tableView.backgroundView = backgroundView
+                tableView.backgroundView?.isHidden = false
+                tableView.separatorStyle = .none
             }
-            tableView.backgroundView?.isHidden = false
-            tableView.separatorStyle = .none
         } else {
             tableView.separatorStyle = .singleLine
             tableView.backgroundView?.isHidden = true

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ The `delegate` parameter passed in the initializer of the `DataSourceController`
 ```swift
 protocol DataSourceControllerDelegate: AnyObject {
     func backgroundMessageLabel(for view: UIView) -> UILabel?
+    func backgroundEmptyView(for view: UIView) -> UIView?
     func dataSourceWasMutated(_: DataSourceController)
     func dataSourceWasMutated(_: DataSourceController, section: Int)
     func dataSourceWasMutated(_: DataSourceController, rows: [IndexPath])
@@ -214,11 +215,12 @@ All functions have a default empty implementation to make them optional protocol
 
 That is, the delegate mainly notifies of changes in the `DataSourceController` instance triggered by the mutating functions available in the API (see [API Reference](#api-reference) below for details). The delegate will usually be the object with the `UITableView` or `UICollectionView` instance, since most likely a part of the displayed list will need to be reloaded.
 
-In addition, in case the `totalRowCount` property of the `DataSourceController` instance is 0 (meaning that there are no rows), the controller will try to display the `UILabel` instance provided by the function
+In addition, in case the `totalRowCount` property of the `DataSourceController` instance is 0 (meaning that there are no rows), the controller will try to display either the `UIView` or the `UILabel` instances provided by the functions
 ```swift
 func backgroundMessageLabel(for view: UIView) -> UILabel?
+func backgroundEmptyView(for view: UIView) -> UIView?
 ```
-as the background. Note that this function is optional, and therefore it may be omitted. The parameter `view` is either the `UITableView` or `UICollectionView` instance whose `dataSource` is the `DataSourceController`.
+as the background. Note that both these functions are optional, and therefore it may be omitted. If both functions are implemented, the framework will prioritize the `backgroundEmptyView(for:)` function. The parameter `view` is either the `UITableView` or `UICollectionView` instance whose `dataSource` is the `DataSourceController`.
 
 ### UITableView header and footer
 


### PR DESCRIPTION
We enable the usage of a `UIView` instance as the background view when the data source contains no rows. Previous method is marked as `deprecated`, but can still be used.